### PR TITLE
Fixed an issue where default path loading failed.

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -183,7 +183,7 @@ let type: string = cred.getType();
 如果你调用 `new Credential()` 时传入空， 将通过凭证提供链来为你获取凭证。
 
 #### 1. 环境凭证
-程序首先会在环境变量里寻找环境凭证，如果定义了 `ALICLOUD_ACCESS_KEY`  和 `ALICLOUD_SECRET_KEY` 环境变量且不为空，程序将使用他们创建凭证。如否则，程序会在配置文件中加载和寻找凭证。
+程序首先会在环境变量里寻找环境凭证，如果定义了 `ALIBABA_CLOUD_ACCESS_KEY_ID`  和 `ALIBABA_CLOUD_ACCESS_KEY_SECRET` 环境变量且不为空，程序将使用他们创建凭证。如否则，程序会在配置文件中加载和寻找凭证。
 
 #### 2. 配置文件
 如果用户主目录存在默认文件 `~/.alibabacloud/credentials` （Windows 为 `C:\Users\USER_NAME\.alibabacloud\credentials`），程序会自动创建指定类型和名称的凭证。默认文件可以不存在，但解析错误会抛出异常。不同的项目、工具之间可以共用这个配置文件，因为超出项目之外，也不会被意外提交到版本控制。Windows 上可以使用环境变量引用到主目录 %UserProfile%。类 Unix 的系统可以使用环境变量 $HOME 或 ~ (tilde)。 可以通过定义 `ALIBABA_CLOUD_CREDENTIALS_FILE` 环境变量修改默认文件的路径。

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ let type: string = cred.getType();
 If you call `new Credential()` with empty, it will use provider chain to get credential for you.
 
 #### 1. Environment Credentials
-The program first looks for environment credentials in the environment variable. If the `ALICLOUD_ACCESS_KEY` and `ALICLOUD_SECRET_KEY` environment variables are defined and are not empty, the program will use them to create the default credential. If not, the program loads and looks for the client in the configuration file.
+The program first looks for environment credentials in the environment variable. If the `ALIBABA_CLOUD_ACCESS_KEY_ID` and `ALIBABA_CLOUD_ACCESS_KEY_SECRET` environment variables are defined and are not empty, the program will use them to create the default credential. If not, the program loads and looks for the client in the configuration file.
 
 #### 2. Config File
 If there is `~/.alibabacloud/credentials` default file (Windows shows `C:\Users\USER_NAME\.alibabacloud\credentials`), the program will automatically create credential with the name of 'default'. The default file may not exist, but a parse error throws an exception. The specified files can also be loaded indefinitely: `AlibabaCloud::load('/data/credentials', 'vfs://AlibabaCloud/credentials', ...);` This configuration file can be shared between different projects and between different tools. Because it is outside the project and will not be accidentally committed to the version control. Environment variables can be used on Windows to refer to the home directory %UserProfile%. Unix-like systems can use the environment variable $HOME or ~ (tilde). The path to the default file can be modified by defining the `ALIBABA_CLOUD_CREDENTIALS_FILE` environment variable.

--- a/src/provider/profile_credentials_provider.ts
+++ b/src/provider/profile_credentials_provider.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 import ICredential from '../icredential';
 import Config from '../config';
 
-const DEFAULT_PATH = '~/.alibabacloud/credentials';
+const DEFAULT_PATH = process.env.HOME + '/.alibabacloud/credentials';
 
 export default {
   getCredential(credentialName: string = 'default'): ICredential {


### PR DESCRIPTION
The fs.existSync() method cannot resolve the user's home path starting with "~", which causes the program to fail to load the default credential file. Use the HOME environment variable to replace the original default path.