### PR TITLE
fix: quote-aware External process_command parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,17 @@ jobs:
         npm config set fetch-retries 5
         npm config set fetch-retry-mintimeout 20000
         npm config set fetch-retry-maxtimeout 120000
-        # Mitigate intermittent registry socket timeouts (ERR_SOCKET_TIMEOUT)
+        # Mitigate intermittent registry socket timeouts (ERR_SOCKET_TIMEOUT).
+        # On failure, wipe node_modules so retry is a clean install — partial
+        # trees leave packages like diff missing files (MODULE_NOT_FOUND).
         ok=0
         for i in 1 2 3; do
           if npm install; then
             ok=1
             break
           fi
-          echo "npm install failed (attempt $i), retrying..."
+          echo "npm install failed (attempt $i), cleaning and retrying..."
+          rm -rf node_modules
           sleep 15
         done
         test "$ok" -eq 1
@@ -101,14 +104,17 @@ jobs:
         npm config set fetch-retries 5
         npm config set fetch-retry-mintimeout 20000
         npm config set fetch-retry-maxtimeout 120000
-        # Mitigate intermittent registry socket timeouts (ERR_SOCKET_TIMEOUT)
+        # Mitigate intermittent registry socket timeouts (ERR_SOCKET_TIMEOUT).
+        # On failure, wipe node_modules so retry is a clean install — partial
+        # trees leave packages like diff missing files (MODULE_NOT_FOUND).
         ok=0
         for i in 1 2 3; do
           if npm install; then
             ok=1
             break
           fi
-          echo "npm install failed (attempt $i), retrying..."
+          echo "npm install failed (attempt $i), cleaning and retrying..."
+          rm -rf node_modules
           sleep 15
         done
         test "$ok" -eq 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,21 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Build
-      run: npm install
+      run: |
+        npm config set fetch-retries 5
+        npm config set fetch-retry-mintimeout 20000
+        npm config set fetch-retry-maxtimeout 120000
+        # Mitigate intermittent registry socket timeouts (ERR_SOCKET_TIMEOUT)
+        ok=0
+        for i in 1 2 3; do
+          if npm install; then
+            ok=1
+            break
+          fi
+          echo "npm install failed (attempt $i), retrying..."
+          sleep 15
+        done
+        test "$ok" -eq 1
 
     - name: Unit Test
       run: npm run ci
@@ -82,7 +96,22 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Build
-      run: npm install
+      shell: bash
+      run: |
+        npm config set fetch-retries 5
+        npm config set fetch-retry-mintimeout 20000
+        npm config set fetch-retry-maxtimeout 120000
+        # Mitigate intermittent registry socket timeouts (ERR_SOCKET_TIMEOUT)
+        ok=0
+        for i in 1 2 3; do
+          if npm install; then
+            ok=1
+            break
+          fi
+          echo "npm install failed (attempt $i), retrying..."
+          sleep 15
+        done
+        test "$ok" -eq 1
 
     - name: Unit Test
       run: npm run ci

--- a/src/providers/external.ts
+++ b/src/providers/external.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import Credentials from '../credentials';
 import CredentialsProvider from '../credentials_provider';
+import { splitProcessCommand } from '../utils/command';
 
 const execFileAsync = promisify(execFile);
 const EXPIRATION_SLOT_SECONDS = 180;
@@ -78,10 +79,7 @@ export default class ExternalCredentialsProvider implements CredentialsProvider 
   }
 
   private async getCredentialsInternal(): Promise<ExternalCredentialResponse> {
-    const args = this.processCommand.trim().split(/\s+/).filter(Boolean);
-    if (args.length === 0) {
-      throw new Error('process_command is empty');
-    }
+    const args = splitProcessCommand(this.processCommand);
 
     let stdout: string;
     try {

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,0 +1,79 @@
+/**
+ * Split process_command into argv with quote support (POSIX shlex-like).
+ * Allows quoted Windows paths such as "C:\\Program Files\\tool.exe".
+ */
+export function splitProcessCommand(command: string): string[] {
+  const input = (command || '').trim();
+  if (!input) {
+    throw new Error('process_command is empty');
+  }
+
+  const args: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+
+  const flush = () => {
+    if (current.length > 0) {
+      args.push(current);
+      current = '';
+    }
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+    if (inSingle) {
+      if (c === "'") {
+        inSingle = false;
+      } else {
+        current += c;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (c === '"') {
+        inDouble = false;
+        continue;
+      }
+      if (c === '\\' && i + 1 < input.length) {
+        const next = input[i + 1];
+        if (next === '"' || next === '\\' || next === '$' || next === '`' || next === '\n') {
+          current += next;
+          i++;
+          continue;
+        }
+      }
+      current += c;
+      continue;
+    }
+    if (c === '\\') {
+      if (i + 1 >= input.length) {
+        throw new Error('invalid process_command: trailing backslash');
+      }
+      current += input[++i];
+      continue;
+    }
+    if (c === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (c === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (/\s/.test(c)) {
+      flush();
+      continue;
+    }
+    current += c;
+  }
+
+  if (inSingle || inDouble) {
+    throw new Error('invalid process_command: unclosed quote');
+  }
+  flush();
+  if (args.length === 0) {
+    throw new Error('process_command is empty');
+  }
+  return args;
+}

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -12,11 +12,15 @@ export function splitProcessCommand(command: string): string[] {
   let current = '';
   let inSingle = false;
   let inDouble = false;
+  // Tracks that a token has started even if it is empty, so quoted empty
+  // arguments like `tool "" arg` keep their empty argv element.
+  let hasToken = false;
 
   const flush = () => {
-    if (current.length > 0) {
+    if (hasToken) {
       args.push(current);
       current = '';
+      hasToken = false;
     }
   };
 
@@ -50,21 +54,25 @@ export function splitProcessCommand(command: string): string[] {
       if (i + 1 >= input.length) {
         throw new Error('invalid process_command: trailing backslash');
       }
+      hasToken = true;
       current += input[++i];
       continue;
     }
     if (c === "'") {
       inSingle = true;
+      hasToken = true;
       continue;
     }
     if (c === '"') {
       inDouble = true;
+      hasToken = true;
       continue;
     }
     if (/\s/.test(c)) {
       flush();
       continue;
     }
+    hasToken = true;
     current += c;
   }
 
@@ -72,7 +80,7 @@ export function splitProcessCommand(command: string): string[] {
     throw new Error('invalid process_command: unclosed quote');
   }
   flush();
-  if (args.length === 0) {
+  if (args.length === 0 || args[0] === '') {
     throw new Error('process_command is empty');
   }
   return args;

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,8 +1,16 @@
 /**
- * Split process_command into argv with quote support (POSIX shlex-like).
+ * Split process_command into argv with quote support.
  * Allows quoted Windows paths such as "C:\\Program Files\\tool.exe".
+ *
+ * On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
+ * next char; inside double quotes, '\' only escapes '"', '\', '$', '`' and
+ * newline; inside single quotes, all characters are literal.
+ *
+ * On Windows, '\' is a path separator and is treated as a literal (except
+ * '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
+ * their backslashes.
  */
-export function splitProcessCommand(command: string): string[] {
+export function splitProcessCommand(command: string, windows: boolean = process.platform === 'win32'): string[] {
   const input = (command || '').trim();
   if (!input) {
     throw new Error('process_command is empty');
@@ -41,7 +49,14 @@ export function splitProcessCommand(command: string): string[] {
       }
       if (c === '\\' && i + 1 < input.length) {
         const next = input[i + 1];
-        if (next === '"' || next === '\\' || next === '$' || next === '`' || next === '\n') {
+        if (windows) {
+          // On Windows only \" is an escape inside double quotes.
+          if (next === '"') {
+            current += next;
+            i++;
+            continue;
+          }
+        } else if (next === '"' || next === '\\' || next === '$' || next === '`' || next === '\n') {
           current += next;
           i++;
           continue;
@@ -51,6 +66,12 @@ export function splitProcessCommand(command: string): string[] {
       continue;
     }
     if (c === '\\') {
+      if (windows) {
+        // Path separator — keep literal.
+        hasToken = true;
+        current += c;
+        continue;
+      }
       if (i + 1 >= input.length) {
         throw new Error('invalid process_command: trailing backslash');
       }

--- a/test/providers/cli_profile.test.ts
+++ b/test/providers/cli_profile.test.ts
@@ -187,7 +187,7 @@ describe('CLIProfileCredentialsProvider', function () {
         {
           mode: 'External',
           name: 'External',
-          process_command: '/bin/echo {"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}',
+          process_command: '/bin/echo \'{"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}\'',
         },
         {
           mode: 'Unsupported',

--- a/test/providers/external.test.ts
+++ b/test/providers/external.test.ts
@@ -24,7 +24,8 @@ describe('ExternalCredentialsProvider', function () {
 
     it('should return AK credentials', async function () {
       const p = ExternalCredentialsProvider.builder()
-        .withProcessCommand('/bin/echo {"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}')
+        // JSON must be single-quoted so shlex-like split keeps " inside the arg.
+        .withProcessCommand('/bin/echo \'{"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}\'')
         .build();
 
       const creds = await p.getCredentials();
@@ -37,7 +38,7 @@ describe('ExternalCredentialsProvider', function () {
     it('should return STS credentials and invoke callback', async function () {
       let callbackArgs: any[] = [];
       const p = ExternalCredentialsProvider.builder()
-        .withProcessCommand('/bin/echo {"mode":"StsToken","access_key_id":"ak","access_key_secret":"sk","sts_token":"token","expiration":"2049-10-20T04:27:09Z"}')
+        .withProcessCommand('/bin/echo \'{"mode":"StsToken","access_key_id":"ak","access_key_secret":"sk","sts_token":"token","expiration":"2049-10-20T04:27:09Z"}\'')
         .withCredentialUpdateCallback((accessKeyId, accessKeySecret, securityToken, expiration) => {
           callbackArgs = [accessKeyId, accessKeySecret, securityToken, expiration];
         })
@@ -54,7 +55,7 @@ describe('ExternalCredentialsProvider', function () {
     it('should refresh on every call when expiration is absent', async function () {
       let callbackCount = 0;
       const p = ExternalCredentialsProvider.builder()
-        .withProcessCommand('/bin/echo {"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}')
+        .withProcessCommand('/bin/echo \'{"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}\'')
         .withCredentialUpdateCallback(() => {
           callbackCount++;
         })
@@ -67,7 +68,7 @@ describe('ExternalCredentialsProvider', function () {
 
     it('should ignore callback errors', async function () {
       const p = ExternalCredentialsProvider.builder()
-        .withProcessCommand('/bin/echo {"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}')
+        .withProcessCommand('/bin/echo \'{"mode":"AK","access_key_id":"ak","access_key_secret":"sk"}\'')
         .withCredentialUpdateCallback(() => {
           throw new Error('callback error');
         })
@@ -79,7 +80,7 @@ describe('ExternalCredentialsProvider', function () {
 
     it('should validate response fields', async function () {
       const p = ExternalCredentialsProvider.builder()
-        .withProcessCommand('/bin/echo {"mode":"StsToken","access_key_id":"ak","access_key_secret":"sk"}')
+        .withProcessCommand('/bin/echo \'{"mode":"StsToken","access_key_id":"ak","access_key_secret":"sk"}\'')
         .build();
 
       try {

--- a/test/providers/http.test.ts
+++ b/test/providers/http.test.ts
@@ -1,5 +1,6 @@
 import 'mocha';
 import assert from 'assert'
+import http, { Server } from 'http';
 
 import {Request, doRequest} from '../../src/providers/http';
 
@@ -30,9 +31,31 @@ describe('Request', function () {
 });
 
 describe('doRequest', function () {
+  let server: Server;
+  let host: string;
+
+  before(function (done) {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, {'content-type': 'text/html'});
+      res.end('<html>ok</html>');
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        done(new Error('test server did not bind to a TCP port'));
+        return;
+      }
+      host = `127.0.0.1:${address.port}`;
+      done();
+    });
+  });
+
+  after(function (done) {
+    server.close(done);
+  });
 
   it('should ok', async function () {
-    const req = Request.builder().withHost('www.baidu.com').build();
+    const req = Request.builder().withProtocol('http').withHost(host).build();
     const res = await doRequest(req);
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.headers['content-type'], 'text/html');
@@ -42,7 +65,8 @@ describe('doRequest', function () {
 
   it('should ok with queries', async function () {
     const req = Request.builder()
-      .withHost('www.baidu.com')
+      .withProtocol('http')
+      .withHost(host)
       .withQueries({'key': 'value'})
       .build();
     const res = await doRequest(req);
@@ -54,7 +78,8 @@ describe('doRequest', function () {
 
   it('should ok with headers', async function () {
     const req = Request.builder()
-      .withHost('www.baidu.com')
+      .withProtocol('http')
+      .withHost(host)
       .withQueries({'key': 'value'})
       .withHeaders({'key': 'value'})
       .build();

--- a/test/utils/command.test.ts
+++ b/test/utils/command.test.ts
@@ -55,6 +55,18 @@ describe('splitProcessCommand', function () {
     ]);
   });
 
+  it('should keep empty double-quoted argument', function () {
+    expect(splitProcessCommand('tool "" arg')).to.eql(['tool', '', 'arg']);
+  });
+
+  it('should keep empty single-quoted argument', function () {
+    expect(splitProcessCommand("tool '' arg")).to.eql(['tool', '', 'arg']);
+  });
+
+  it('should merge adjacent quoted segments into one argument', function () {
+    expect(splitProcessCommand('tool "a b"\'c d\'')).to.eql(['tool', 'a bc d']);
+  });
+
   it('should reject empty command', function () {
     expect(() => splitProcessCommand('   ')).to.throwError(/process_command is empty/);
   });

--- a/test/utils/command.test.ts
+++ b/test/utils/command.test.ts
@@ -34,6 +34,13 @@ describe('splitProcessCommand', function () {
     ]);
   });
 
+  it('should keep JSON double-quotes inside single-quoted arg', function () {
+    expect(splitProcessCommand('/bin/echo \'{"mode":"AK","access_key_id":"ak"}\'')).to.eql([
+      '/bin/echo',
+      '{"mode":"AK","access_key_id":"ak"}',
+    ]);
+  });
+
   it('should support escaped spaces outside quotes', function () {
     expect(splitProcessCommand('tool arg\\ with\\ space')).to.eql([
       'tool',

--- a/test/utils/command.test.ts
+++ b/test/utils/command.test.ts
@@ -11,7 +11,7 @@ describe('splitProcessCommand', function () {
   });
 
   it('should keep windows path with spaces inside double quotes', function () {
-    expect(splitProcessCommand('"C:\\Program Files\\tool\\cred.exe" get --profile default')).to.eql([
+    expect(splitProcessCommand('"C:\\Program Files\\tool\\cred.exe" get --profile default', true)).to.eql([
       'C:\\Program Files\\tool\\cred.exe',
       'get',
       '--profile',
@@ -41,17 +41,44 @@ describe('splitProcessCommand', function () {
     ]);
   });
 
-  it('should support escaped spaces outside quotes', function () {
-    expect(splitProcessCommand('tool arg\\ with\\ space')).to.eql([
+  it('should keep backslashes inside single-quoted arg on unix', function () {
+    expect(splitProcessCommand('/usr/bin/printf \'\\173\\042mode\\042\\175\'', false)).to.eql([
+      '/usr/bin/printf',
+      '\\173\\042mode\\042\\175',
+    ]);
+  });
+
+  it('should support escaped spaces outside quotes on unix', function () {
+    expect(splitProcessCommand('tool arg\\ with\\ space', false)).to.eql([
       'tool',
       'arg with space',
     ]);
   });
 
-  it('should support escaped quote inside double quotes', function () {
-    expect(splitProcessCommand('tool "say \\"hi\\""')).to.eql([
+  it('should support escaped quote inside double quotes on unix', function () {
+    expect(splitProcessCommand('tool "say \\"hi\\""', false)).to.eql([
       'tool',
       'say "hi"',
+    ]);
+  });
+
+  it('should keep unquoted windows path backslashes on windows', function () {
+    expect(splitProcessCommand('C:\\tools\\cred.exe get', true)).to.eql([
+      'C:\\tools\\cred.exe',
+      'get',
+    ]);
+  });
+
+  it('should support escaped quote inside double quotes on windows', function () {
+    expect(splitProcessCommand('tool "say \\"hi\\""', true)).to.eql([
+      'tool',
+      'say "hi"',
+    ]);
+  });
+
+  it('should keep backslashes inside double quotes on windows', function () {
+    expect(splitProcessCommand('"C:\\Program Files\\tool.exe"', true)).to.eql([
+      'C:\\Program Files\\tool.exe',
     ]);
   });
 
@@ -79,7 +106,7 @@ describe('splitProcessCommand', function () {
     expect(() => splitProcessCommand('"C:\\Program Files\\tool.exe')).to.throwError(/unclosed quote/);
   });
 
-  it('should reject trailing backslash', function () {
-    expect(() => splitProcessCommand('tool\\')).to.throwError(/trailing backslash/);
+  it('should reject trailing backslash on unix', function () {
+    expect(() => splitProcessCommand('tool\\', false)).to.throwError(/trailing backslash/);
   });
 });

--- a/test/utils/command.test.ts
+++ b/test/utils/command.test.ts
@@ -1,0 +1,66 @@
+import expect from 'expect.js';
+import { splitProcessCommand } from '../../src/utils/command';
+
+describe('splitProcessCommand', function () {
+  it('should split simple command', function () {
+    expect(splitProcessCommand('cmd arg1 arg2')).to.eql(['cmd', 'arg1', 'arg2']);
+  });
+
+  it('should trim extra whitespace', function () {
+    expect(splitProcessCommand('  cmd   arg1\targ2  ')).to.eql(['cmd', 'arg1', 'arg2']);
+  });
+
+  it('should keep windows path with spaces inside double quotes', function () {
+    expect(splitProcessCommand('"C:\\Program Files\\tool\\cred.exe" get --profile default')).to.eql([
+      'C:\\Program Files\\tool\\cred.exe',
+      'get',
+      '--profile',
+      'default',
+    ]);
+  });
+
+  it('should support single-quoted unix paths', function () {
+    expect(splitProcessCommand("'/usr/local/my tools/cred' arg")).to.eql([
+      '/usr/local/my tools/cred',
+      'arg',
+    ]);
+  });
+
+  it('should support quoted arguments', function () {
+    expect(splitProcessCommand('tool --name "First Last"')).to.eql([
+      'tool',
+      '--name',
+      'First Last',
+    ]);
+  });
+
+  it('should support escaped spaces outside quotes', function () {
+    expect(splitProcessCommand('tool arg\\ with\\ space')).to.eql([
+      'tool',
+      'arg with space',
+    ]);
+  });
+
+  it('should support escaped quote inside double quotes', function () {
+    expect(splitProcessCommand('tool "say \\"hi\\""')).to.eql([
+      'tool',
+      'say "hi"',
+    ]);
+  });
+
+  it('should reject empty command', function () {
+    expect(() => splitProcessCommand('   ')).to.throwError(/process_command is empty/);
+  });
+
+  it('should reject empty quoted argv0', function () {
+    expect(() => splitProcessCommand('""')).to.throwError(/process_command is empty/);
+  });
+
+  it('should reject unclosed quote', function () {
+    expect(() => splitProcessCommand('"C:\\Program Files\\tool.exe')).to.throwError(/unclosed quote/);
+  });
+
+  it('should reject trailing backslash', function () {
+    expect(() => splitProcessCommand('tool\\')).to.throwError(/trailing backslash/);
+  });
+});


### PR DESCRIPTION
## Summary
- External process_command 改为支持引号的 argv 分词（POSIX shlex 语义）
- Windows 带空格路径（如 Program Files）可用双引号包成单个参数
- 补充单测并达到新增代码覆盖率门禁