### PR TITLE
fix: POSIX line-continuation in process_command splitting

### DIFF
--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -3,8 +3,9 @@
  * Allows quoted Windows paths such as "C:\\Program Files\\tool.exe".
  *
  * On Unix, escape rules follow POSIX shlex: outside quotes, '\' escapes the
- * next char; inside double quotes, '\' only escapes '"', '\', '$', '`' and
- * newline; inside single quotes, all characters are literal.
+ * next char; inside double quotes, '\' only escapes '"', '\', '$' and '`';
+ * backslash-newline is a line continuation (both removed) outside single
+ * quotes; inside single quotes, all characters are literal.
  *
  * On Windows, '\' is a path separator and is treated as a literal (except
  * '\"' inside double quotes), so unquoted paths like C:\tools\cred.exe keep
@@ -56,7 +57,11 @@ export function splitProcessCommand(command: string, windows: boolean = process.
             i++;
             continue;
           }
-        } else if (next === '"' || next === '\\' || next === '$' || next === '`' || next === '\n') {
+        } else if (next === '\n') {
+          // Backslash-newline is a line continuation: both removed.
+          i++;
+          continue;
+        } else if (next === '"' || next === '\\' || next === '$' || next === '`') {
           current += next;
           i++;
           continue;
@@ -74,6 +79,11 @@ export function splitProcessCommand(command: string, windows: boolean = process.
       }
       if (i + 1 >= input.length) {
         throw new Error('invalid process_command: trailing backslash');
+      }
+      if (input[i + 1] === '\n') {
+        // Backslash-newline is a line continuation: both removed.
+        i++;
+        continue;
       }
       hasToken = true;
       current += input[++i];

--- a/test/utils/command.test.ts
+++ b/test/utils/command.test.ts
@@ -94,6 +94,14 @@ describe('splitProcessCommand', function () {
     expect(splitProcessCommand('tool "a b"\'c d\'')).to.eql(['tool', 'a bc d']);
   });
 
+  it('should treat backslash-newline outside quotes as line continuation on unix', function () {
+    expect(splitProcessCommand('tool arg1 \\\n arg2', false)).to.eql(['tool', 'arg1', 'arg2']);
+  });
+
+  it('should treat backslash-newline inside double quotes as line continuation on unix', function () {
+    expect(splitProcessCommand('tool "a\\\nb"', false)).to.eql(['tool', 'ab']);
+  });
+
   it('should reject empty command', function () {
     expect(() => splitProcessCommand('   ')).to.throwError(/process_command is empty/);
   });


### PR DESCRIPTION
## Summary
- Treat backslash-newline as POSIX line continuation (both removed) in `splitProcessCommand`, outside quotes and inside double quotes, matching shlex semantics (follow-up to #144).
- Add test cases for both continuation positions.